### PR TITLE
Fix: Exclude node_modules in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /frontend/.env
 /backend/.env
 todo
+/frontend/node_modules
+/backend/node_modules


### PR DESCRIPTION
## Description
- Resolved the issue of tracking node_modules in version control.
- Updated the .gitignore file to exclude the node_modules directory.
- This ensures that unnecessary files are not included in the repository, reducing clutter and improving performance for contributors.


- Fixes #93

## Type of change
-bug fix


